### PR TITLE
Replace media queries with Bootstrap ones

### DIFF
--- a/template/src/styles/variables.scss
+++ b/template/src/styles/variables.scss
@@ -37,9 +37,9 @@ $size-small: "0.75rem"; // 12px
 
 // Media queries
 $iphone5-viewport: "max-width: 320px";
-$xs-viewport: "max-width: 480px";
-$sm-viewport: "max-width: 768px";
-$md-viewport: "max-width: 1024px";
-$lg-viewport: "min-width: 1024px";
-$xl-viewport: "min-width: 1367px";
+$xs-viewport: "max-width: 575px";
+$sm-viewport: "max-width: 767px";
+$md-viewport: "max-width: 991px";
+$lg-viewport: "max-width: 1199px";
+$xl-viewport: "max-width: 1399px";
 $retina-display: "(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)";


### PR DESCRIPTION
## Media queries update 🔍 

This pull request replaces the existing media queries with the ones from Bootstrap, since they are more broadly known and used.

I based this change on [this documentation](https://getbootstrap.com/docs/4.0/layout/overview/) from Bootstrap's website. Boostrap's queries are mobile-first, but I  adapted the queries to be **desktop-first** instead. I chose to favor desktop-first instead of adding both mobile and desktop-first queries, since having both could lead to code difficult to maintain.

Closes #2 